### PR TITLE
Optional XR SDK PreInit

### DIFF
--- a/com.valve.openvr/Editor/OpenVRSettingsEditor.cs
+++ b/com.valve.openvr/Editor/OpenVRSettingsEditor.cs
@@ -27,6 +27,12 @@ namespace Unity.XR.OpenVR.Editor
 
         private SerializedProperty m_MirrorViewMode;
 
+        private const string kPreInit = "PreInit";
+
+        static GUIContent s_PreInit = EditorGUIUtility.TrTextContent("XR SDK PreInit");
+
+        private SerializedProperty m_PreInit;
+
         public GUIContent WindowsTab;
         private int tab = 0;
 
@@ -76,6 +82,10 @@ namespace Unity.XR.OpenVR.Editor
             {
                 m_MirrorViewMode = serializedObject.FindProperty(kMirrorViewModeKey);
             }
+            if (m_PreInit == null)
+            {
+                m_PreInit = serializedObject.FindProperty(kPreInit);
+            }
 
             serializedObject.Update();
 
@@ -89,9 +99,9 @@ namespace Unity.XR.OpenVR.Editor
             if (tab == 0)
             {
                 EditorGUILayout.PropertyField(m_InitializationType, s_InitializationType);
-
                 EditorGUILayout.PropertyField(m_StereoRenderingMode, s_StereoRenderingMode);
                 EditorGUILayout.PropertyField(m_MirrorViewMode, s_MirrorViewMode);
+                EditorGUILayout.PropertyField(m_PreInit, s_PreInit);
             }
             EditorGUILayout.EndVertical();
 

--- a/com.valve.openvr/Runtime/OpenVRLoader.cs
+++ b/com.valve.openvr/Runtime/OpenVRLoader.cs
@@ -443,7 +443,16 @@ namespace Unity.XR.OpenVR
 #if UNITY_EDITOR
         public string GetPreInitLibraryName(BuildTarget buildTarget, BuildTargetGroup buildTargetGroup)
         {
-            return "XRSDKOpenVR";
+            OpenVRSettings settings = OpenVRSettings.GetSettings();
+
+            // Operate normally if we have PreInit enabled.
+            if (settings != null && settings.PreInit) 
+            {
+                return "XRSDKOpenVR";
+            }
+
+            // Returning null prevents XRSDKPreInit.
+            return null;
         }
 
         private static void DisableTickOnReload()

--- a/com.valve.openvr/Runtime/OpenVRSettings.cs
+++ b/com.valve.openvr/Runtime/OpenVRSettings.cs
@@ -59,6 +59,9 @@ namespace Unity.XR.OpenVR
         [SerializeField, Tooltip("Which eye to use when rendering the headset view to the main window (none, left, right, or a composite of both + OpenVR overlays)")]
         public MirrorViewModes MirrorView = MirrorViewModes.Right;
 
+        [SerializeField, Tooltip("Should the library interface with XR SDK PreInit.")]
+        public bool PreInit = false;
+
         public const string StreamingAssetsFolderName = "SteamVR";
         public const string ActionManifestFileName = "legacy_manifest.json";
         public static string GetStreamingSteamVRPath(bool create = true)


### PR DESCRIPTION
The use of [Unity XR SDK PreInit](https://docs.unity3d.com/Manual/xrsdk-pre-init-interface.html) causes the XR System, and Steam VR, to be initialized in builds even with _Initialize XR on Startup_ is disabled in the _XR Plug-in Management settings_.

These changes add a new option to the _OpenVR_ settings (_XR Plug-in Management -> OpenVR_) that allows you to toggle XR SDK PreInit. 

Fixes #80 