### PR TITLE
Retrieve depth texture from correct stage and for the correct eye

### DIFF
--- a/Providers/Display/Display.cpp
+++ b/Providers/Display/Display.cpp
@@ -758,9 +758,9 @@ bool OpenVRDisplayProvider::SubmitToCompositor( vr::EVREye eEye, int nStage )
 	tex.eColorSpace = vr::ColorSpace_Auto;
 
 	// Check if we have a valid depth buffer
-	if (m_pNativeDepthTextures[eEye][nStage])
+	if (m_pNativeDepthTextures[nStage][nTexIndex])
 	{
-		tex.depth.handle = m_pNativeDepthTextures[eEye][nStage];
+		tex.depth.handle = m_pNativeDepthTextures[nStage][nTexIndex];
 	}
 
 	if ( !m_bIsOverlayApplication )


### PR DESCRIPTION
The current code in `Display.cpp` that retrieves the depth textures seems wrong. All the textures variables (`m_UnityTextures`, `m_pNativeColorTextures` and `m_pNativeDepthTextures`) have the stage as first dimension and the eye as second dimension. On top of that, when single pass rendering is used, only the (depth) texture of the left eye is relevant (as it's a texture array holding both eyes).

This is easily fixed, and AFAICS didn't cause any regression in what I was able to test. But additional testing would be nice, since I'm not even sure if I was testing it properly. The flags are set to `vr::Submit_Default`, so does that cause the compositor to infer the type of the texture? Or does this actually make the entire `tex.depth.handle` go unnoticed? In case of the latter, that might explain how this mistake went unnoticed and would require a fix to pick the right flags as well..